### PR TITLE
added the require field to compososer json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,8 @@
     ],
     "autoload": {
         "files": ["src/AdvancedRoute.php"]
+    },
+     "require": {
+        "Laravel/framework": "5.3.*"
     }
 }


### PR DESCRIPTION
acording to pakagist this field is needed in order to register the repo with them so ``composer requiere`` can be used and thus making this package easier to install