### PR TITLE
made it work with php 5 and with index methods

### DIFF
--- a/src/AdvancedRoute.php
+++ b/src/AdvancedRoute.php
@@ -41,21 +41,28 @@ class AdvancedRoute {
         $cleaned = str_replace(['any', 'get', 'post', 'delete'], '', $methodName);
         $snaked = \Illuminate\Support\Str::snake($cleaned, ' ');
         $slug = str_slug($snaked, '-');
-        
+
         if($slug == "index")
             $slug = "";
         foreach ($method->getParameters() as $parameter) {
 
-            if ($parameter->getClass() != null) {
+            if (self::hasType($parameter)) {
                 continue;
             }
             $slug .= sprintf('/{%s%s}', $parameter->getName(), $parameter->isDefaultValueAvailable() ? '?' : '');
         }
-        
-        if($slug != null && $slug[0] == '/')
+
+        if($slug != null && $slug[0] ==  '/')
             return substr($slug,1);
-        
+
         return $slug;
+    }
+
+    protected static function hasType(ReflectionParameter $param) {
+        //TODO: if php7 use the native method
+
+        preg_match('/\[\s\<\w+?>\s([\w]+)/s', $param->__toString(), $matches);
+        return isset($matches[1]) ? true : false;
     }
 
 }

--- a/src/AdvancedRoute.php
+++ b/src/AdvancedRoute.php
@@ -41,12 +41,20 @@ class AdvancedRoute {
         $cleaned = str_replace(['any', 'get', 'post', 'delete'], '', $methodName);
         $snaked = \Illuminate\Support\Str::snake($cleaned, ' ');
         $slug = str_slug($snaked, '-');
+        
+        if($slug == "index")
+            $slug = "";
         foreach ($method->getParameters() as $parameter) {
-            if ($parameter->hasType()) {
+
+            if ($parameter->getClass() != null) {
                 continue;
             }
             $slug .= sprintf('/{%s%s}', $parameter->getName(), $parameter->isDefaultValueAvailable() ? '?' : '');
         }
+        
+        if($slug[0] == '/')
+            return substr($slug,1);
+        
         return $slug;
     }
 

--- a/src/AdvancedRoute.php
+++ b/src/AdvancedRoute.php
@@ -52,7 +52,7 @@ class AdvancedRoute {
             $slug .= sprintf('/{%s%s}', $parameter->getName(), $parameter->isDefaultValueAvailable() ? '?' : '');
         }
         
-        if($slug[0] == '/')
+        if($slug != null && $slug[0] == '/')
             return substr($slug,1);
         
         return $slug;


### PR DESCRIPTION
->hasType was introduced in PHP7, since laravel supports PHP5 getClass() != null should be used as it yields the same result

index methods should be handled whit no slug (IE "/") so if slug == index, remove it, and remove the first "/"