### PR TITLE
Fixes and an enhancement

### DIFF
--- a/src/AdvancedRoute.php
+++ b/src/AdvancedRoute.php
@@ -2,34 +2,92 @@
 
 class AdvancedRoute {
 
+    // If EMIT_ROUTE_STATEMENTS, create the directory /tmp/controllerRoutes and
+    // write one file each time we are called with the Route command that can
+    // be used to replace the AdvancedRoute command in the routes file.
+    //
+    // Since Laravel has officially deprecated the Route::controller, if we want
+    // to do the same, let's have this class emit the route statements we need.
+    const EMIT_ROUTE_STATEMENTS = false;
+
+    private static $httpMethods = ['any', 'get', 'post', 'put', 'patch', 'delete'];
+    private static $methodNameAtStartOfStringPattern = null;
+
     public static function controller($path, $controllerClassName) {
         $class = new ReflectionClass('App\Http\Controllers\\' . $controllerClassName);
 
+        $routes = [];
+
         $publicMethods = $class->getMethods(ReflectionMethod::IS_PUBLIC);
 
+        // The methods from each class will be in some random order, but mostly likely in the
+        // order they were defined in the original file.  However, when issuing route commands we
+        // need to ensure that more specific routes take precedences over ones with a parameter.
+        // So for example if we have both the routes
+        // Route::get('foo/{any}', 'FooController@anyIndex');
+        // Route::get('foo/about', 'FooController@getAbout');
+        // We need to ensure that the '/foo/about' route is issued first or it will never be invoked
+        // as the anyIndex will be will be called instead.
+        $methods = [];
         foreach ($publicMethods as $method) {
-            $methodName = $method->name;
-            if ($methodName == 'getMiddleware') {
+            if ($method->name == 'getMiddleware')
                 continue;
-            }
-            if (self::stringStartsWith($methodName, 'any')) {
-                $slug = self::slug($method);
-                //var_dump($slug);
-                Route::any($path . '/' . $slug, $controllerClassName . '@' . $methodName);
-            }
-            if (self::stringStartsWith($methodName, 'get')) {
-                $slug = self::slug($method);
-                //var_dump($slug);
-                Route::get($path . '/' . $slug, $controllerClassName . '@' . $methodName);
-            }
-            if (self::stringStartsWith($methodName, 'post')) {
-                $slug = self::slug($method);
-                //var_dump($slug);
-                Route::post($path . '/' . $slug, $controllerClassName . '@' . $methodName);
+
+            $method->slug = self::slug($method);
+            $methods[] = $method; 
+        }
+
+        // Sort the routes so that the routes without any parameters, one with no {, come first.
+        usort($methods, function($a, $b) {
+            $aHasParam = false !== strpos($a->slug, '{');
+            $bHasParam = false !== strpos($b->slug, '{');
+
+            if (!$aHasParam && $bHasParam)
+                return -1;
+            if (!$bHasParam && $aHasParam)
+                return 1;
+            return (strcmp($a->slug, $b->slug));
+
+        });
+
+        foreach ($methods as $method) {
+            $slug = $method->slug;
+            $methodName = $method->name;
+
+            $httpMethod = null;
+            foreach(self::$httpMethods as $httpMethod)
+            {
+                if (self::stringStartsWith($methodName, $httpMethod)) {
+                    Route::$httpMethod($path . '/' . $slug, $controllerClassName . '@' . $methodName);
+
+                    $route = new \stdClass();
+                    $route->httpMethod = $httpMethod;
+                    $route->prefix = sprintf("Route::%-4s('%s',", $httpMethod, $path . '/' . $slug);
+                    $route->target = $controllerClassName . '@' . $methodName;
+                    $routes[] = $route;
+                    break;
+                }
             }
         }
 
-        Route::get($path, $controllerClassName . '@anyIndex');
+        if (self::EMIT_ROUTE_STATEMENTS) {
+            // Compute max length of the "prefix" of each route command so that when we issue the strings
+            // we can make all the 2nd parameters line up verticaly.  Easier to read and thus easier to check
+            // to ensure we are emitting the right routes.
+            $maxPrefixLen = 0;
+            array_walk($routes, function($route) use (&$maxPrefixLen) {
+                $l = strlen($route->prefix);
+                if ($l > $maxPrefixLen)
+                    $maxPrefixLen = $l;
+            });
+
+            if (!is_dir('/tmp/controllerRoutes'))
+                mkdir('/tmp/controllerRoutes');
+            $routeList = sprintf("<?php\n// %s \"Controller\" Routes\n", $controllerClassName);
+            foreach ($routes as $route)
+                $routeList .= sprintf("%-{$maxPrefixLen}s '%s');\n", $route->prefix, $route->target);
+            file_put_contents("/tmp/controllerRoutes/{$controllerClassName}.php", $routeList . PHP_EOL);
+        }
     }
 
     protected static function stringStartsWith($string, $match) {
@@ -37,8 +95,14 @@ class AdvancedRoute {
     }
 
     protected static function slug($method) {
-        $methodName = $method->name;
-        $cleaned = str_replace(['any', 'get', 'post', 'delete'], '', $methodName);
+        // Can't use str_replace to remove the httpMethod from the method name because this removes als strings whereever
+        // they appear in the string, so for example, getCompanyname, becomes "compname" instead of companyname because "any"
+        // is removed from the word company in addition to the removal of "get" from the front of the string. Use a preg
+        // to anchor the search to the front of the method name.
+        if (!self::$methodNameAtStartOfStringPattern)
+            self::$methodNameAtStartOfStringPattern = '/^('.implode('|', self::$httpMethods).')/';
+
+        $cleaned = preg_replace(self::$methodNameAtStartOfStringPattern, '', $method->name);
         $snaked = \Illuminate\Support\Str::snake($cleaned, ' ');
         $slug = str_slug($snaked, '-');
 
@@ -49,7 +113,7 @@ class AdvancedRoute {
             if (self::hasType($parameter)) {
                 continue;
             }
-            $slug .= sprintf('/{%s%s}', $parameter->getName(), $parameter->isDefaultValueAvailable() ? '?' : '');
+            $slug .= sprintf('/{%s%s}', strtolower($parameter->getName()), $parameter->isDefaultValueAvailable() ? '?' : '');
         }
 
         if($slug != null && $slug[0] ==  '/')


### PR DESCRIPTION
The AdvancedRoute package was very helpful when working on our port to
Laravel 5.3, so many thanks for the work in creating it. We have over
700 routes across more than 30 controllers, so trying to replace the
deprecated Route::controller manually would have been a nightmare.
However, we did encounter a couple of issues in this package which I
had to fix and I also added one enhancement that was really useful to
us.

Firstly, the slug method was using a str_replace to remove the http
method name from the start of controller method, but unfortuately that
removed all occurances of all the http method names from the entire
method name. So example, the method getCompanyname, became "compname"
instead of "companyname". This method now uses a preg to anchor the
search to the start of the method name.

Secondly, in addition to get, post and any, we also use the patch and
delete http methods, so I generalized the code to support both of those
and, for completness, "put" as well.

Lastly, we wanted to move away from ::controller routing entirely and
use explicit route commands, but as I mentioned above that would have
mean crafting 700+ statements for the routes/web.php file. However,
since AdvancedRoute had already computed the necessary routes, I added
the "optional" capability to have it emit all those routes in the exact
format required for insertion into routes/web.php. If the
EMIT_ROUTE_STATEMENTS class variable is set to true, a
/tmp/controllerRoutes directory will be created and one file for each
call to AdvancedRoute::controller will be written to that directory
containing the computed routes. Obviously this only needs to be done
once.