### PR TITLE
Support alternate namespaces

### DIFF
--- a/src/AdvancedRoute.php
+++ b/src/AdvancedRoute.php
@@ -14,7 +14,7 @@ class AdvancedRoute {
     private static $methodNameAtStartOfStringPattern = null;
 
     public static function controller($path, $controllerClassName) {
-        $class = new ReflectionClass('App\Http\Controllers\\' . $controllerClassName);
+        $class = new ReflectionClass(app()->getNamespace().'Http\Controllers\\' . $controllerClassName);
 
         $routes = [];
 


### PR DESCRIPTION
Using `php artisan app:name` to change the application name currently breaks the class. This will let it use the currently set application name .