### PR TITLE
First checks if the class itself exists (without presumed namespace).…

### DIFF
--- a/src/AdvancedRoute.php
+++ b/src/AdvancedRoute.php
@@ -14,7 +14,11 @@ class AdvancedRoute {
     private static $methodNameAtStartOfStringPattern = null;
 
     public static function controller($path, $controllerClassName) {
-        $class = new ReflectionClass(app()->getNamespace() . 'Http\Controllers\\' . $controllerClassName);
+        if( class_exists($controllerClassName) ) {
+            $class = new ReflectionClass($controllerClassName);
+        } else {
+            $class = new ReflectionClass(app()->getNamespace() . 'Http\Controllers\\' . $controllerClassName);
+        }
 
         $routes = [];
 


### PR DESCRIPTION
…  Only add presumed namespace if class does not exist.

Works for cases where we have custom namespaces, such as:

AdvancedRoute::controller('/', \MyNamespace\Blablabla\Controllers\ExampleController::class);