### PR TITLE
Set missing route to be generated last

### DIFF
--- a/src/AdvancedRoute.php
+++ b/src/AdvancedRoute.php
@@ -56,21 +56,14 @@ class AdvancedRoute {
             return (strcmp($a->slug, $b->slug));
         });
 
+        $addMissingMethod = false;
         foreach ($methods as $method) {
             $slug = $method->slug;
             $methodName = $method->name;
             $slug_path = $path . '/' . $slug;
 
-            if($methodName == 'missingMethod')
-            {
-                $slug_path = str_replace('//', '/', $path.'/'.'{_missing}');
-                Route::any($slug_path, $controllerClassName . '@' . $methodName);
-
-                $route = new \stdClass();
-                $route->httpMethod = 'any';
-                $route->prefix = sprintf("Route::%-4s('%s',", 'any', $slug_path);
-                $route->target = $controllerClassName . '@' . $methodName;
-                $routes[] = $route;
+            if ($methodName == 'missingMethod') {
+                $addMissingMethod = true;
                 continue;
             }
 
@@ -87,6 +80,20 @@ class AdvancedRoute {
                     break;
                 }
             }
+        }
+
+        // add the _missing route last otherwise it will be hit by routes whose
+        // method names start with a letter greater than the letter 'm'
+        if ($addMissingMethod) {
+                $methodName = 'missingMethod';
+                $slug_path = str_replace('//', '/', $path.'/'.'{_missing}');
+                Route::any($slug_path, $controllerClassName . '@' . $methodName);
+
+                $route = new \stdClass();
+                $route->httpMethod = 'any';
+                $route->prefix = sprintf("Route::%-4s('%s',", 'any', $slug_path);
+                $route->target = $controllerClassName . '@' . $methodName;
+                $routes[] = $route;
         }
 
         if (self::EMIT_ROUTE_STATEMENTS) {


### PR DESCRIPTION
Add the _missing route last otherwise it will be hit by urls whose urls/method names start with a letter greater than the letter 'm'.
For example
 Route::any ('/list-builder/{_missing}'
was getting generated before
Route::get ('/list-builder/xlsx-list/{download?}'
So any calls to /list-builder/xlsx-list were being resolved to the missing method route.