### PR TITLE
Adds feature that automatically names routes.

### DIFF
--- a/src/AdvancedRoute.php
+++ b/src/AdvancedRoute.php
@@ -72,6 +72,12 @@ class AdvancedRoute {
                 if (self::stringStartsWith($methodName, $httpMethod)) {
                     Route::$httpMethod($slug_path, $controllerClassName . '@' . $methodName);
 
+                    $routeName = strtolower(str_replace('Controller', '', substr($controllerClassName, strrpos($controllerClassName,"\\")+1)));
+                    $routeName .= ".{$httpMethod}.";
+                    $routeName .= str_replace($httpMethod, '', strtolower($methodName));
+
+                    Route::$httpMethod($slug_path, $controllerClassName . '@' . $methodName)->name($routeName);
+
                     $route = new \stdClass();
                     $route->httpMethod = $httpMethod;
                     $route->prefix = sprintf("Route::%-4s('%s',", $httpMethod, $slug_path);


### PR DESCRIPTION
With this functionality, routes created with laravel-advanced-route will be automatically named. By default it looks like this:

ControllerName.Method.Action

Example:
PostController@getIndex

will be:
post.get.index

This way you can use Laravel's route('name') Helper.